### PR TITLE
Urlencode query string when searching

### DIFF
--- a/nyaa/url.go
+++ b/nyaa/url.go
@@ -1,6 +1,9 @@
 package nyaa
 
-import "fmt"
+import (
+	"fmt"
+	u "net/url"
+)
 
 const (
 	nyaaBaseURL    = "https://nyaa.si/?page=rss&q=+"
@@ -75,7 +78,7 @@ func buildURL(opts SearchOptions) (string, error) {
 	}
 
 	if opts.Query != "" {
-		url += opts.Query
+		url += u.QueryEscape(opts.Query)
 	}
 
 	if opts.Provider == "nyaa" {


### PR DESCRIPTION
When searching with invalid characters (such as spaces or slashes), the program will try and request it anyway without ending. Somehow couldn't reproduce the error when using sukebei as a provider. Should fix irevenko/koneko#8 but I don't have a mac to test.